### PR TITLE
Remove "ngsa" namespace from container image policy "excludedNamespaces" list

### DIFF
--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -1981,7 +1981,7 @@
                 "policyDefinitionId": "[variables('policyResourceIdEnforceImageSource')]",
                 "parameters": {
                     "allowedContainerImagesRegex": {
-                        "value": "[concat(variables('defaultAcrName'),'.azurecr.io/.+$|mcr.microsoft.com/.+$|docker.io/fluxcd/flux.+$|docker.io/weaveworks/kured.+$|docker.io/library/.+$')]"
+                        "value": "[concat(variables('defaultAcrName'),'.azurecr.io/.+$|mcr.microsoft.com/.+$|docker.io/fluxcd/flux.+$|docker.io/weaveworks/kured.+$|docker.io/retaildevcrew/.+$|docker.io/library/.+$')]"
                     },
                     "excludedNamespaces": {
                         "value": [
@@ -1989,8 +1989,7 @@
                             "gatekeeper-system",
                             "azure-arc",
                             "flux-cd",
-                            "ingress",
-                            "ngsa"
+                            "ingress"
                         ]
                     },
                     "effect": {

--- a/gitops/ngsa/ngsa-memory.yaml
+++ b/gitops/ngsa/ngsa-memory.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: retaildevcrew/ngsa-app:beta
+          image: docker.io/retaildevcrew/ngsa-app:beta
           imagePullPolicy: Always
 
           args: 


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

Back out one of the solutions to the ACR challenge from the default setup.

- ngsa namespace is removed from policy exclusion list
- add `docker.io/retaildevcrew/.+$` to container image regex
- use full url with `docker.io/` in the ngsa-memory deployment

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/asb-hack/issues/353
